### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/travis-additional-deps.py
+++ b/travis-additional-deps.py
@@ -6,7 +6,7 @@ import subprocess
 
 deps = []
 undeps = []
-pyv = os.environ.get('TRAVIS_PYTHON_VERSION', '%s.%s' % sys.version_info[:2])
+pyv = os.environ.get('TRAVIS_PYTHON_VERSION', '{0!s}.{1!s}'.format(*sys.version_info[:2]))
 if pyv == '2.6':
     deps.extend(['unittest2', 'argparse', 'importlib', 'mock'])
 elif pyv == '3.2':


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:radon?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:radon?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
